### PR TITLE
refactor tests into reusable harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,12 +816,46 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.6.0",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -784,6 +866,18 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -1927,6 +2021,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
+dependencies = [
+ "clap 4.4.11",
+ "termcolor",
+ "threadpool",
 ]
 
 [[package]]
@@ -3383,6 +3488,7 @@ dependencies = [
  "assert_matches",
  "bincode",
  "bytemuck",
+ "libtest-mimic",
  "log",
  "serde",
  "solana-frozen-abi",
@@ -4903,6 +5009,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5288,6 +5403,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"

--- a/address-lookup-table/program/Cargo.toml
+++ b/address-lookup-table/program/Cargo.toml
@@ -18,10 +18,16 @@ solana-program = "1.17.7"
 spl-pod = "0.1.0"
 spl-program-error = "0.3.0"
 
+[dev-dependencies]
+assert_matches = "1.5.0"
+libtest-mimic = "0.6"
+solana-program-test = "1.17.7"
+solana-sdk = "1.17.7"
+
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[dev-dependencies]
-assert_matches = "1.5.0"
-solana-program-test = "1.17.7"
-solana-sdk = "1.17.7"
+[[test]]
+name = "main"
+path = "tests/main.rs"
+harness = false

--- a/address-lookup-table/program/tests/harness/close_lookup_table.rs
+++ b/address-lookup-table/program/tests/harness/close_lookup_table.rs
@@ -1,12 +1,11 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    assert_matches::assert_matches,
-    common::{
+    super::common::{
         add_lookup_table_account, assert_ix_error, new_address_lookup_table,
         overwrite_slot_hashes_with_slots, setup_test_context,
     },
-    solana_program_test::*,
+    assert_matches::assert_matches,
     solana_sdk::{
         address_lookup_table::instruction::close_lookup_table,
         clock::Clock,
@@ -17,11 +16,8 @@ use {
     },
 };
 
-mod common;
-
-#[tokio::test]
-async fn test_close_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_close_lookup_table(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
     overwrite_slot_hashes_with_slots(&context, &[]);
 
     let lookup_table_address = Pubkey::new_unique();
@@ -55,9 +51,8 @@ async fn test_close_lookup_table() {
         .is_none());
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_not_deactivated() {
-    let mut context = setup_test_context().await;
+pub async fn test_close_lookup_table_not_deactivated(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority_keypair = Keypair::new();
     let initialized_table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
@@ -80,9 +75,8 @@ async fn test_close_lookup_table_not_deactivated() {
     .await;
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_deactivated_in_current_slot() {
-    let mut context = setup_test_context().await;
+pub async fn test_close_lookup_table_deactivated_in_current_slot(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
     let authority_keypair = Keypair::new();
@@ -112,9 +106,8 @@ async fn test_close_lookup_table_deactivated_in_current_slot() {
     .await;
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_recently_deactivated() {
-    let mut context = setup_test_context().await;
+pub async fn test_close_lookup_table_recently_deactivated(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority_keypair = Keypair::new();
     let initialized_table = {
@@ -143,9 +136,8 @@ async fn test_close_lookup_table_recently_deactivated() {
     .await;
 }
 
-#[tokio::test]
-async fn test_close_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_close_immutable_lookup_table(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let initialized_table = new_address_lookup_table(None, 10);
     let lookup_table_address = Pubkey::new_unique();
@@ -167,9 +159,8 @@ async fn test_close_immutable_lookup_table() {
     .await;
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+pub async fn test_close_lookup_table_with_wrong_authority(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let wrong_authority = Keypair::new();
@@ -192,9 +183,8 @@ async fn test_close_lookup_table_with_wrong_authority() {
     .await;
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+pub async fn test_close_lookup_table_without_signing(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);

--- a/address-lookup-table/program/tests/harness/common.rs
+++ b/address-lookup-table/program/tests/harness/common.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "test-sbf")]
-#![allow(dead_code)]
 
 use {
     solana_program_test::*,
@@ -20,12 +19,8 @@ use {
     std::borrow::Cow,
 };
 
-pub async fn setup_test_context() -> ProgramTestContext {
-    let program_test = ProgramTest::new(
-        "solana_address_lookup_table_program",
-        id(),
-        processor!(solana_address_lookup_table_program::processor::process),
-    );
+pub async fn setup_test_context(program_file: &str) -> ProgramTestContext {
+    let program_test = ProgramTest::new(program_file, id(), None);
     program_test.start_with_context().await
 }
 

--- a/address-lookup-table/program/tests/harness/create_lookup_table.rs
+++ b/address-lookup-table/program/tests/harness/create_lookup_table.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "test-sbf")]
 
 use {
+    super::common::{assert_ix_error, overwrite_slot_hashes_with_slots, setup_test_context},
     assert_matches::assert_matches,
-    common::{assert_ix_error, overwrite_slot_hashes_with_slots, setup_test_context},
     solana_program_test::*,
     solana_sdk::{
         address_lookup_table::{
@@ -21,23 +21,16 @@ use {
     },
 };
 
-mod common;
-
-pub async fn setup_test_context_without_authority_feature() -> ProgramTestContext {
-    let mut program_test = ProgramTest::new(
-        "solana_address_lookup_table_program",
-        id(),
-        processor!(solana_address_lookup_table_program::processor::process),
-    );
+async fn setup_test_context_without_authority_feature(program_file: &str) -> ProgramTestContext {
+    let mut program_test = ProgramTest::new(program_file, id(), None);
     program_test.deactivate_feature(
         feature_set::relax_authority_signer_check_for_lookup_table_creation::id(),
     );
     program_test.start_with_context().await
 }
 
-#[tokio::test]
-async fn test_create_lookup_table_idempotent() {
-    let mut context = setup_test_context().await;
+pub async fn test_create_lookup_table_idempotent(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let test_recent_slot = 123;
     overwrite_slot_hashes_with_slots(&context, &[test_recent_slot]);
@@ -95,9 +88,8 @@ async fn test_create_lookup_table_idempotent() {
     }
 }
 
-#[tokio::test]
-async fn test_create_lookup_table_not_idempotent() {
-    let mut context = setup_test_context_without_authority_feature().await;
+pub async fn test_create_lookup_table_not_idempotent(program_file: &str) {
+    let mut context = setup_test_context_without_authority_feature(program_file).await;
 
     let test_recent_slot = 123;
     overwrite_slot_hashes_with_slots(&context, &[test_recent_slot]);
@@ -135,9 +127,8 @@ async fn test_create_lookup_table_not_idempotent() {
     }
 }
 
-#[tokio::test]
-async fn test_create_lookup_table_use_payer_as_authority() {
-    let mut context = setup_test_context().await;
+pub async fn test_create_lookup_table_use_payer_as_authority(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let test_recent_slot = 123;
     overwrite_slot_hashes_with_slots(&context, &[test_recent_slot]);
@@ -156,9 +147,8 @@ async fn test_create_lookup_table_use_payer_as_authority() {
     assert_matches!(client.process_transaction(transaction).await, Ok(()));
 }
 
-#[tokio::test]
-async fn test_create_lookup_table_missing_signer() {
-    let mut context = setup_test_context_without_authority_feature().await;
+pub async fn test_create_lookup_table_missing_signer(program_file: &str) {
+    let mut context = setup_test_context_without_authority_feature(program_file).await;
     let unsigned_authority_address = Pubkey::new_unique();
 
     let mut ix = create_lookup_table_signed(
@@ -178,9 +168,8 @@ async fn test_create_lookup_table_missing_signer() {
     .await;
 }
 
-#[tokio::test]
-async fn test_create_lookup_table_not_recent_slot() {
-    let mut context = setup_test_context().await;
+pub async fn test_create_lookup_table_not_recent_slot(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
     let payer = &context.payer;
     let authority_address = Pubkey::new_unique();
 
@@ -195,9 +184,8 @@ async fn test_create_lookup_table_not_recent_slot() {
     .await;
 }
 
-#[tokio::test]
-async fn test_create_lookup_table_pda_mismatch() {
-    let mut context = setup_test_context().await;
+pub async fn test_create_lookup_table_pda_mismatch(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
     let test_recent_slot = 123;
     overwrite_slot_hashes_with_slots(&context, &[test_recent_slot]);
     let payer = &context.payer;

--- a/address-lookup-table/program/tests/harness/deactivate_lookup_table.rs
+++ b/address-lookup-table/program/tests/harness/deactivate_lookup_table.rs
@@ -1,13 +1,12 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    assert_matches::assert_matches,
-    common::{
+    super::common::{
         add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
     },
-    solana_program_test::*,
+    assert_matches::assert_matches,
     solana_sdk::{
-        address_lookup_table::{instruction::freeze_lookup_table, state::AddressLookupTable},
+        address_lookup_table::{instruction::deactivate_lookup_table, state::AddressLookupTable},
         instruction::InstructionError,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -15,11 +14,8 @@ use {
     },
 };
 
-mod common;
-
-#[tokio::test]
-async fn test_freeze_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_deactivate_lookup_table(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let mut initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
@@ -35,7 +31,7 @@ async fn test_freeze_lookup_table() {
     let payer = &context.payer;
     let recent_blockhash = context.last_blockhash;
     let transaction = Transaction::new_signed_with_payer(
-        &[freeze_lookup_table(
+        &[deactivate_lookup_table(
             lookup_table_address,
             authority.pubkey(),
         )],
@@ -51,23 +47,22 @@ async fn test_freeze_lookup_table() {
         .unwrap()
         .unwrap();
     let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
-    assert_eq!(lookup_table.meta.authority, None);
+    assert_eq!(lookup_table.meta.deactivation_slot, 1);
 
-    // Check that only the authority changed
-    initialized_table.meta.authority = None;
+    // Check that only the deactivation slot changed
+    initialized_table.meta.deactivation_slot = 1;
     assert_eq!(initialized_table, lookup_table);
 }
 
-#[tokio::test]
-async fn test_freeze_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_deactivate_immutable_lookup_table(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let initialized_table = new_address_lookup_table(None, 10);
     let lookup_table_address = Pubkey::new_unique();
     add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
 
     let authority = Keypair::new();
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
+    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
 
     assert_ix_error(
         &mut context,
@@ -78,20 +73,19 @@ async fn test_freeze_immutable_lookup_table() {
     .await;
 }
 
-#[tokio::test]
-async fn test_freeze_deactivated_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_deactivate_already_deactivated(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let initialized_table = {
-        let mut table = new_address_lookup_table(Some(authority.pubkey()), 10);
+        let mut table = new_address_lookup_table(Some(authority.pubkey()), 0);
         table.meta.deactivation_slot = 0;
         table
     };
     let lookup_table_address = Pubkey::new_unique();
     add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
 
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
+    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
 
     assert_ix_error(
         &mut context,
@@ -102,9 +96,8 @@ async fn test_freeze_deactivated_lookup_table() {
     .await;
 }
 
-#[tokio::test]
-async fn test_freeze_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+pub async fn test_deactivate_lookup_table_with_wrong_authority(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let wrong_authority = Keypair::new();
@@ -112,7 +105,7 @@ async fn test_freeze_lookup_table_with_wrong_authority() {
     let lookup_table_address = Pubkey::new_unique();
     add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
 
-    let ix = freeze_lookup_table(lookup_table_address, wrong_authority.pubkey());
+    let ix = deactivate_lookup_table(lookup_table_address, wrong_authority.pubkey());
 
     assert_ix_error(
         &mut context,
@@ -123,16 +116,15 @@ async fn test_freeze_lookup_table_with_wrong_authority() {
     .await;
 }
 
-#[tokio::test]
-async fn test_freeze_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+pub async fn test_deactivate_lookup_table_without_signing(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
     let lookup_table_address = Pubkey::new_unique();
     add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
 
-    let mut ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
+    let mut ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
     ix.accounts[1].is_signer = false;
 
     assert_ix_error(
@@ -140,26 +132,6 @@ async fn test_freeze_lookup_table_without_signing() {
         ix,
         None,
         InstructionError::MissingRequiredSignature,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_freeze_empty_lookup_table() {
-    let mut context = setup_test_context().await;
-
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
-    let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
-
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidInstructionData,
     )
     .await;
 }

--- a/address-lookup-table/program/tests/harness/extend_lookup_table.rs
+++ b/address-lookup-table/program/tests/harness/extend_lookup_table.rs
@@ -1,10 +1,11 @@
 #![cfg(feature = "test-sbf")]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
-    assert_matches::assert_matches,
-    common::{
+    super::common::{
         add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
     },
+    assert_matches::assert_matches,
     solana_program_test::*,
     solana_sdk::{
         account::{ReadableAccount, WritableAccount},
@@ -20,8 +21,6 @@ use {
     },
     std::{borrow::Cow, result::Result},
 };
-
-mod common;
 
 struct ExpectedTableAccount {
     lamports: u64,
@@ -79,9 +78,8 @@ async fn run_test_case(context: &mut ProgramTestContext, test_case: TestCase<'_>
     }
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_extend_lookup_table(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
     let authority = Keypair::new();
     let current_bank_slot = 1;
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -158,9 +156,8 @@ async fn test_extend_lookup_table() {
     }
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+pub async fn test_extend_lookup_table_with_wrong_authority(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let wrong_authority = Keypair::new();
@@ -185,9 +182,8 @@ async fn test_extend_lookup_table_with_wrong_authority() {
     .await;
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+pub async fn test_extend_lookup_table_without_signing(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
@@ -212,9 +208,8 @@ async fn test_extend_lookup_table_without_signing() {
     .await;
 }
 
-#[tokio::test]
-async fn test_extend_deactivated_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_extend_deactivated_lookup_table(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let initialized_table = {
@@ -242,9 +237,8 @@ async fn test_extend_deactivated_lookup_table() {
     .await;
 }
 
-#[tokio::test]
-async fn test_extend_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+pub async fn test_extend_immutable_lookup_table(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let initialized_table = new_address_lookup_table(None, 1);
@@ -268,9 +262,8 @@ async fn test_extend_immutable_lookup_table() {
     .await;
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table_without_payer() {
-    let mut context = setup_test_context().await;
+pub async fn test_extend_lookup_table_without_payer(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
@@ -294,9 +287,8 @@ async fn test_extend_lookup_table_without_payer() {
     .await;
 }
 
-#[tokio::test]
-async fn test_extend_prepaid_lookup_table_without_payer() {
-    let mut context = setup_test_context().await;
+pub async fn test_extend_prepaid_lookup_table_without_payer(program_file: &str) {
+    let mut context = setup_test_context(program_file).await;
 
     let authority = Keypair::new();
     let lookup_table_address = Pubkey::new_unique();

--- a/address-lookup-table/program/tests/harness/mod.rs
+++ b/address-lookup-table/program/tests/harness/mod.rs
@@ -1,0 +1,157 @@
+//! Address Lookup Table program test harness
+#![cfg(feature = "test-sbf")]
+
+pub mod close_lookup_table;
+pub mod common;
+pub mod create_lookup_table;
+pub mod deactivate_lookup_table;
+pub mod extend_lookup_table;
+pub mod freeze_lookup_table;
+
+use {libtest_mimic::Trial, solana_program_test::tokio};
+
+const PROGRAM_IMPLEMENTATIONS: &[&str] = &[
+    "solana_address_lookup_table_program",
+    // More program implementations...
+];
+
+macro_rules! async_trial {
+    ($test_func:path, $program_file:ident) => {{
+        Trial::test(stringify!($test_func), move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async { $test_func($program_file).await });
+            Ok(())
+        })
+    }};
+}
+
+pub struct AddressLookupTestHarness;
+impl AddressLookupTestHarness {
+    pub fn tests() -> Vec<Trial> {
+        PROGRAM_IMPLEMENTATIONS
+            .iter()
+            .flat_map(|program_file| {
+                vec![
+                    async_trial!(
+                        create_lookup_table::test_create_lookup_table_idempotent,
+                        program_file
+                    ),
+                    async_trial!(
+                        create_lookup_table::test_create_lookup_table_not_idempotent,
+                        program_file
+                    ),
+                    async_trial!(
+                        create_lookup_table::test_create_lookup_table_use_payer_as_authority,
+                        program_file
+                    ),
+                    async_trial!(
+                        create_lookup_table::test_create_lookup_table_missing_signer,
+                        program_file
+                    ),
+                    async_trial!(
+                        create_lookup_table::test_create_lookup_table_not_recent_slot,
+                        program_file
+                    ),
+                    async_trial!(
+                        create_lookup_table::test_create_lookup_table_pda_mismatch,
+                        program_file
+                    ),
+                    async_trial!(close_lookup_table::test_close_lookup_table, program_file),
+                    async_trial!(
+                        close_lookup_table::test_close_lookup_table_not_deactivated,
+                        program_file
+                    ),
+                    async_trial!(
+                        close_lookup_table::test_close_lookup_table_deactivated_in_current_slot,
+                        program_file
+                    ),
+                    async_trial!(
+                        close_lookup_table::test_close_lookup_table_recently_deactivated,
+                        program_file
+                    ),
+                    async_trial!(
+                        close_lookup_table::test_close_immutable_lookup_table,
+                        program_file
+                    ),
+                    async_trial!(
+                        close_lookup_table::test_close_lookup_table_with_wrong_authority,
+                        program_file
+                    ),
+                    async_trial!(
+                        close_lookup_table::test_close_lookup_table_without_signing,
+                        program_file
+                    ),
+                    async_trial!(
+                        deactivate_lookup_table::test_deactivate_lookup_table,
+                        program_file
+                    ),
+                    async_trial!(
+                        deactivate_lookup_table::test_deactivate_immutable_lookup_table,
+                        program_file
+                    ),
+                    async_trial!(
+                        deactivate_lookup_table::test_deactivate_already_deactivated,
+                        program_file
+                    ),
+                    async_trial!(
+                        deactivate_lookup_table::test_deactivate_lookup_table_with_wrong_authority,
+                        program_file
+                    ),
+                    async_trial!(
+                        deactivate_lookup_table::test_deactivate_lookup_table_without_signing,
+                        program_file
+                    ),
+                    async_trial!(extend_lookup_table::test_extend_lookup_table, program_file),
+                    async_trial!(
+                        extend_lookup_table::test_extend_lookup_table_with_wrong_authority,
+                        program_file
+                    ),
+                    async_trial!(
+                        extend_lookup_table::test_extend_lookup_table_without_signing,
+                        program_file
+                    ),
+                    async_trial!(
+                        extend_lookup_table::test_extend_deactivated_lookup_table,
+                        program_file
+                    ),
+                    async_trial!(
+                        extend_lookup_table::test_extend_immutable_lookup_table,
+                        program_file
+                    ),
+                    async_trial!(
+                        extend_lookup_table::test_extend_lookup_table_without_payer,
+                        program_file
+                    ),
+                    async_trial!(
+                        extend_lookup_table::test_extend_prepaid_lookup_table_without_payer,
+                        program_file
+                    ),
+                    async_trial!(freeze_lookup_table::test_freeze_lookup_table, program_file),
+                    async_trial!(
+                        freeze_lookup_table::test_freeze_immutable_lookup_table,
+                        program_file
+                    ),
+                    async_trial!(
+                        freeze_lookup_table::test_freeze_deactivated_lookup_table,
+                        program_file
+                    ),
+                    async_trial!(
+                        freeze_lookup_table::test_freeze_lookup_table_with_wrong_authority,
+                        program_file
+                    ),
+                    async_trial!(
+                        freeze_lookup_table::test_freeze_lookup_table_without_signing,
+                        program_file
+                    ),
+                    async_trial!(
+                        freeze_lookup_table::test_freeze_empty_lookup_table,
+                        program_file
+                    ),
+                ]
+            })
+            .collect()
+    }
+}

--- a/address-lookup-table/program/tests/main.rs
+++ b/address-lookup-table/program/tests/main.rs
@@ -1,0 +1,24 @@
+//! Address Lookup Table program tests
+
+#[cfg(feature = "test-sbf")]
+pub mod harness;
+
+#[cfg(feature = "test-sbf")]
+use solana_program_test::tokio;
+
+#[cfg(feature = "test-sbf")]
+#[tokio::main]
+async fn main() {
+    libtest_mimic::run(
+        &libtest_mimic::Arguments::from_args(),
+        harness::AddressLookupTestHarness::tests(),
+    )
+    .exit();
+}
+
+#[cfg(not(feature = "test-sbf"))]
+fn main() {
+    println!();
+    println!("[TESTS SKIPPED]: Address Lookup Table program tests require `cargo test-sbf`.");
+    println!();
+}


### PR DESCRIPTION
This PR refactors the original Address Lookup Table program tests into a
re-usable harness.

Note: WIP.
